### PR TITLE
Replace JCenter with Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -33,7 +33,7 @@ allprojects {
             }
         }
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
JCenter was stopped working (as of ~2022?). As far as I can tell this project still doesn't build, but this addresses one of the reasons for that.